### PR TITLE
修复(聊天): 为 message_process 增加 message_info 防御性检查

### DIFF
--- a/src/chat/message_receive/bot.py
+++ b/src/chat/message_receive/bot.py
@@ -379,19 +379,31 @@ class ChatBot:
             # 确保所有任务已启动
             await self._ensure_started()
 
-            platform = message_data["message_info"].get("platform")
+            # 控制握手等消息可能缺少 message_info，这里直接跳过避免 KeyError
+            if not isinstance(message_data, dict):
+                logger.warning(f"收到无法解析的消息类型: {type(message_data)}，已跳过")
+                return
+            message_info = message_data.get("message_info")
+            if not isinstance(message_info, dict):
+                logger.debug(
+                    "收到缺少 message_info 的消息，已跳过。可用字段: %s",
+                    ", ".join(message_data.keys()),
+                )
+                return
+
+            platform = message_info.get("platform")
 
             if platform == "amaidesu_default":
                 await self.do_s4u(message_data)
                 return
 
-            if message_data["message_info"].get("group_info") is not None:
-                message_data["message_info"]["group_info"]["group_id"] = str(
-                    message_data["message_info"]["group_info"]["group_id"]
+            if message_info.get("group_info") is not None:
+                message_info["group_info"]["group_id"] = str(
+                    message_info["group_info"]["group_id"]
                 )
-            if message_data["message_info"].get("user_info") is not None:
-                message_data["message_info"]["user_info"]["user_id"] = str(
-                    message_data["message_info"]["user_info"]["user_id"]
+            if message_info.get("user_info") is not None:
+                message_info["user_info"]["user_id"] = str(
+                    message_info["user_info"]["user_id"]
                 )
             # print(message_data)
             # logger.debug(str(message_data))


### PR DESCRIPTION
message_process 方法在收到没有 'message_info' 字段的 payload（例如来自 Napcat 的握手/心跳控制消息）时，会因 KeyError 而失败。

此更改增加了防御性检查，在处理前验证 'message_info' 的存在和类型。如果缺失，则记录并跳过该 payload，防止主处理循环崩溃。

## Summary by Sourcery

Add defensive checks in message_process to verify existence and type of message_info before proceeding, skipping and logging unsupported payloads to prevent KeyError crashes.

Bug Fixes:
- Prevent KeyError in message_process by skipping payloads missing or with invalid message_info.

Enhancements:
- Log warnings for non-dict messages and debug info when message_info is absent.
- Refactor to use a local message_info variable and streamline group_id/user_id string conversion.